### PR TITLE
build: use base kernel config from ALARM

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,7 @@ function check_arch {
 function check_tools {
 	local tools=(
 		bsdtar
+		curl
 		mkfs.fat
 		partprobe
 		sfdisk
@@ -183,8 +184,14 @@ function build_kernel {
 	if [ ! -f build/boot/vmlinuz* ]; then
 		git clone $KERNEL_GIT_REPO build/linux-sp11 --single-branch --branch $KERNEL_GIT_BRANCH --depth 1
 
-		make -C build/linux-sp11 johan_defconfig
-		./build/linux-sp11/scripts/kconfig/merge_config.sh -O build/linux-sp11 -m build/linux-sp11/.config kernel_config_fragment
+		# Download base kernel config for Arch Linux ARM
+		curl -Lo alarm_base_config "https://raw.githubusercontent.com/archlinuxarm/PKGBUILDs/54d7921c1be7c42a7c2ccd956bfef842be676eac/core/linux-aarch64-rc/config"
+
+		./build/linux-sp11/scripts/kconfig/merge_config.sh -O build/linux-sp11 -m \
+				alarm_base_config \
+				build/linux-sp11/arch/arm64/configs/johan_defconfig \
+				kernel_config_fragment
+
 		make -C build/linux-sp11 olddefconfig
 
 		mkdir -p build/boot build/modules


### PR DESCRIPTION
Uses the base config from Arch Linux ARM when building the kernel, in order to enable more features such as Docker support. The johan_defconfig and this repo's kernel config fragment are then merged on top of it. Note: increases build time to around ~45 mins on the CI. Currently uses the 6.14.0-rc2 config as the rc3 isn't in ALARM yet.

[Build logs and image file](https://github.com/andre4ik3/linux-surface-pro-11/actions/runs/13521429359/job/37781400037)

Closes #3