### PR TITLE
Update threads number to match CPUs in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -177,7 +177,7 @@ function build_kernel {
 		export INSTALL_PATH=../boot
 		export INSTALL_MOD_PATH=../modules
 
-		make -C build/linux-sp11 -j12
+		make -C build/linux-sp11 -j$(nproc)
 		make -C build/linux-sp11 modules_install
 		make -C build/linux-sp11 dtbs_install
 		make -C build/linux-sp11 zinstall


### PR DESCRIPTION
Cores number may vary by platform, better not stick to just 12 cores as a fixed variable. Especially for those, running in VM's or WSL. 

Taking the available cores number from system values.